### PR TITLE
Fix: OS-based POC assignment now reads from correct field

### DIFF
--- a/vulnerability-analysis-engine-v3.js
+++ b/vulnerability-analysis-engine-v3.js
@@ -1310,10 +1310,10 @@ class VulnerabilityAnalysisEngineV3 extends VulnerabilityAnalysisEngineV2 {
     }
     
     checkOSRules(findings) {
-        // Extract OS from raw scan data (Qualys 'OS' column)
+        // Extract OS from normalized finding data (stored in asset.operatingSystem by CSV processor)
         const osSamples = findings
-            .map(f => f['OS'] || f['Operating System'] || f.os || '')
-            .filter(os => os && os.trim())
+            .map(f => f.asset?.operatingSystem || f['OS'] || f['Operating System'] || f.os || '')
+            .filter(os => os && os.trim() && os !== 'unknown')
             .slice(0, 10); // Check first 10 findings
         
         if (osSamples.length === 0) {


### PR DESCRIPTION
- checkOSRules was looking for OS in f['OS'], f['Operating System'], f.os
- But CSV processor stores OS in f.asset.operatingSystem
- Added f.asset?.operatingSystem as primary source (highest priority)
- Also filters out 'unknown' values to prevent false matches
- This enables proper POC assignment based on Windows/Linux/Unix/macOS detection

Fixes #3